### PR TITLE
Add dead time to config

### DIFF
--- a/manifests/file.pp
+++ b/manifests/file.pp
@@ -21,7 +21,8 @@
 #
 define logstashforwarder::file(
   $paths,
-  $fields = ''
+  $fields = '',
+  $dead_time = '1h'
 ) {
 
   validate_array($paths)
@@ -32,7 +33,7 @@ define logstashforwarder::file(
   if ($fields != '') {
     validate_hash($fields)
     $arr_fields = inline_template('<%= @fields.sort.collect { |k,v| "\"#{k}\": \"#{v}\"" }.join(", ") %>')
-    $opt_fields = ",\n      \"fields\": { ${arr_fields} }\n    "
+    $opt_fields = ",\n      \"fields\": { ${arr_fields} },\n      \"dead time\": \"${dead_time}\"\n    "
   }
 
   $content = "    {\n    ${opt_paths}${opt_fields}}"


### PR DESCRIPTION
Dead time is how long lsf keeps a file open after it hasn't been
written to.  By default, this is 24h.  This allows us to specify the
dead time we'd like to use.

Note: we need to have a "newer" version of LSF installed to use dead time, as the elasticsearch repo doesn't have the latest and greatest from the github.  logstash-forwarder/issues/200 explains its use and the need for a newer version.

If an older version gets this config, the field is simply ignored.

Tested on node, output looks like:

```
     {
       "paths": [ "file_path_here" ],
-      "fields": { "type": "lsf_type" }
+      "fields": { "type": "lsf_type" },
+      "dead time": "1h"
     }
```
