### PR TITLE
Update apt::source syntax

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -38,9 +38,10 @@ class logstashforwarder::repo(
         location    => 'http://packages.elasticsearch.org/logstashforwarder/debian',
         release     => 'stable',
         repos       => 'main',
-        key         => 'D88E42B4',
-        key_server  => 'pgp.mit.edu',
-        include_src => false,
+        key         => {
+          'id'     => 'D88E42B4',
+          'server' => 'pgp.mit.edu',
+        },
       }
     }
     'RedHat': {


### PR DESCRIPTION
In version 2.0.0 of puppetlabs/apt the syntax was changed. This brings the module up to the new standard.